### PR TITLE
fix: make Update Azure Data workflow cloudflare-secret compatible

### DIFF
--- a/.github/workflows/update-ip-data.yml
+++ b/.github/workflows/update-ip-data.yml
@@ -8,9 +8,11 @@ on:
     # Allow manual triggering
 
 # This workflow updates both Azure IP ranges and RBAC role definitions
-# Supported secret formats:
-# 1) AZURE_CREDENTIALS (JSON: {"clientId","clientSecret","subscriptionId","tenantId"})
-# 2) Individual secrets: AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_TENANT_ID, AZURE_SUBSCRIPTION_ID
+# Required GitHub secrets:
+# - AZURE_CLIENT_ID
+# - AZURE_CLIENT_SECRET
+# - AZURE_TENANT_ID
+# - AZURE_SUBSCRIPTION_ID
 jobs:
   update-azure-data:
     runs-on: ubuntu-latest
@@ -20,10 +22,6 @@ jobs:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-      GRAPH_TENANT_ID: ${{ secrets.GRAPH_TENANT_ID }}
-      GRAPH_CLIENT_ID: ${{ secrets.GRAPH_CLIENT_ID }}
-      GRAPH_CLIENT_SECRET: ${{ secrets.GRAPH_CLIENT_SECRET }}
 
     steps:
       - name: Checkout repository
@@ -46,35 +44,12 @@ jobs:
       - name: Update Private DNS zone data
         run: npm run update-private-dns-zones
 
-      - name: Azure Login (AZURE_CREDENTIALS JSON)
-        if: ${{ secrets.AZURE_CREDENTIALS != '' }}
-        uses: azure/login@v2
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
-
-      - name: Azure Login (individual AZURE_* secrets)
-        if: ${{ secrets.AZURE_CREDENTIALS == '' }}
+      - name: Azure Login
         uses: azure/login@v2
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-      - name: Export Azure service principal credentials from AZURE_CREDENTIALS
-        if: ${{ secrets.AZURE_CREDENTIALS != '' }}
-        run: |
-          echo '${{ secrets.AZURE_CREDENTIALS }}' > azure-credentials.json
-          echo "AZURE_CLIENT_ID=$(node -p \"JSON.parse(require('fs').readFileSync('azure-credentials.json', 'utf8')).clientId\")" >> $GITHUB_ENV
-          echo "AZURE_CLIENT_SECRET=$(node -p \"JSON.parse(require('fs').readFileSync('azure-credentials.json', 'utf8')).clientSecret\")" >> $GITHUB_ENV
-          echo "AZURE_TENANT_ID=$(node -p \"JSON.parse(require('fs').readFileSync('azure-credentials.json', 'utf8')).tenantId\")" >> $GITHUB_ENV
-          rm azure-credentials.json
-
-      - name: Verify Graph or Azure credentials are present for Entra role fetch
-        run: |
-          if [ -z "${GRAPH_CLIENT_ID}${AZURE_CLIENT_ID}" ] || [ -z "${GRAPH_CLIENT_SECRET}${AZURE_CLIENT_SECRET}" ] || [ -z "${GRAPH_TENANT_ID}${AZURE_TENANT_ID}" ]; then
-            echo "Missing credentials. Set GRAPH_* secrets or AZURE_* secrets."
-            exit 1
-          fi
 
       - name: Update Azure RBAC data
         run: npm run update-rbac-data

--- a/.github/workflows/update-ip-data.yml
+++ b/.github/workflows/update-ip-data.yml
@@ -8,15 +8,22 @@ on:
     # Allow manual triggering
 
 # This workflow updates both Azure IP ranges and RBAC role definitions
-# Required GitHub Secret: AZURE_CREDENTIALS (JSON format for Azure CLI login)
-# Format: {"clientId":"...","clientSecret":"...","subscriptionId":"...","tenantId":"..."}
-# The service principal needs read permissions on role definitions
-
+# Supported secret formats:
+# 1) AZURE_CREDENTIALS (JSON: {"clientId","clientSecret","subscriptionId","tenantId"})
+# 2) Individual secrets: AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_TENANT_ID, AZURE_SUBSCRIPTION_ID
 jobs:
   update-azure-data:
     runs-on: ubuntu-latest
     permissions:
       contents: write  # This is crucial for allowing the workflow to push changes
+    env:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      GRAPH_TENANT_ID: ${{ secrets.GRAPH_TENANT_ID }}
+      GRAPH_CLIENT_ID: ${{ secrets.GRAPH_CLIENT_ID }}
+      GRAPH_CLIENT_SECRET: ${{ secrets.GRAPH_CLIENT_SECRET }}
 
     steps:
       - name: Checkout repository
@@ -39,18 +46,35 @@ jobs:
       - name: Update Private DNS zone data
         run: npm run update-private-dns-zones
 
-      - name: Azure Login
+      - name: Azure Login (AZURE_CREDENTIALS JSON)
+        if: ${{ secrets.AZURE_CREDENTIALS != '' }}
         uses: azure/login@v2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
-      - name: Export Azure service principal credentials
+      - name: Azure Login (individual AZURE_* secrets)
+        if: ${{ secrets.AZURE_CREDENTIALS == '' }}
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Export Azure service principal credentials from AZURE_CREDENTIALS
+        if: ${{ secrets.AZURE_CREDENTIALS != '' }}
         run: |
           echo '${{ secrets.AZURE_CREDENTIALS }}' > azure-credentials.json
-          echo "AZURE_CLIENT_ID=$(node -p "JSON.parse(require('fs').readFileSync('azure-credentials.json', 'utf8')).clientId")" >> $GITHUB_ENV
-          echo "AZURE_CLIENT_SECRET=$(node -p "JSON.parse(require('fs').readFileSync('azure-credentials.json', 'utf8')).clientSecret")" >> $GITHUB_ENV
-          echo "AZURE_TENANT_ID=$(node -p "JSON.parse(require('fs').readFileSync('azure-credentials.json', 'utf8')).tenantId")" >> $GITHUB_ENV
+          echo "AZURE_CLIENT_ID=$(node -p \"JSON.parse(require('fs').readFileSync('azure-credentials.json', 'utf8')).clientId\")" >> $GITHUB_ENV
+          echo "AZURE_CLIENT_SECRET=$(node -p \"JSON.parse(require('fs').readFileSync('azure-credentials.json', 'utf8')).clientSecret\")" >> $GITHUB_ENV
+          echo "AZURE_TENANT_ID=$(node -p \"JSON.parse(require('fs').readFileSync('azure-credentials.json', 'utf8')).tenantId\")" >> $GITHUB_ENV
           rm azure-credentials.json
+
+      - name: Verify Graph or Azure credentials are present for Entra role fetch
+        run: |
+          if [ -z "${GRAPH_CLIENT_ID}${AZURE_CLIENT_ID}" ] || [ -z "${GRAPH_CLIENT_SECRET}${AZURE_CLIENT_SECRET}" ] || [ -z "${GRAPH_TENANT_ID}${AZURE_TENANT_ID}" ]; then
+            echo "Missing credentials. Set GRAPH_* secrets or AZURE_* secrets."
+            exit 1
+          fi
 
       - name: Update Azure RBAC data
         run: npm run update-rbac-data


### PR DESCRIPTION
### Motivation
- The Update Azure Data workflow assumed a single `AZURE_CREDENTIALS` JSON secret, but the Cloudflare migration uses split `AZURE_*` and `GRAPH_*` secrets, causing authentication failures when the JSON blob is not present.
- The Entra ID role fetch script accepts either Azure CLI/service-principal credentials or dedicated Graph credentials, so the workflow must surface both credential styles to run successfully.

### Description
- Added explicit environment bindings for `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`, `GRAPH_CLIENT_ID`, `GRAPH_CLIENT_SECRET`, and `GRAPH_TENANT_ID` to `.github/workflows/update-ip-data.yml` so split secrets provided by Cloudflare are available to steps. 
- Implemented conditional Azure login steps that use `AZURE_CREDENTIALS` JSON when present and fall back to individual `AZURE_*` secrets otherwise. 
- Kept compatibility by exporting `AZURE_*` values from `AZURE_CREDENTIALS` only when that JSON secret exists and adjusted quoting to be workflow-safe. 
- Added a credentials verification step that fails with a clear error message if neither Graph nor Azure credential sets are present before running `fetch-entraid-roles`. 

### Testing
- Validated the modified workflow YAML parsed successfully using `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/update-ip-data.yml'); puts 'ok'"` which printed `ok`.
- Ran `npm ci` which completed successfully with no vulnerabilities reported in this environment. 
- Executed `npm run update-ip-data` which completed index generation and wrote `/public/data/ip-lookup-index.json` despite transient network reachability errors when fetching some Microsoft download pages. 
- Executed `npm run update-private-dns-zones` which failed due to a network `fetch` error in the execution environment and is unrelated to the workflow YAML changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e85a29f62c83318ed8b69732b39d63)