### PR TITLE
fix(ci): use individual Azure secrets for update-ip-data login

### DIFF
--- a/.github/workflows/update-ip-data.yml
+++ b/.github/workflows/update-ip-data.yml
@@ -44,16 +44,23 @@ jobs:
       - name: Update Private DNS zone data
         run: npm run update-private-dns-zones
 
+      - name: Build Azure credentials JSON
+        run: |
+          creds=$(jq -nc \
+            --arg cid "$AZURE_CLIENT_ID" \
+            --arg cs  "$AZURE_CLIENT_SECRET" \
+            --arg tid "$AZURE_TENANT_ID" \
+            --arg sid "$AZURE_SUBSCRIPTION_ID" \
+            '{clientId:$cid, clientSecret:$cs, tenantId:$tid, subscriptionId:$sid}')
+          echo "::add-mask::$creds"
+          echo "AZURE_CREDENTIALS<<EOF" >> "$GITHUB_ENV"
+          echo "$creds" >> "$GITHUB_ENV"
+          echo "EOF" >> "$GITHUB_ENV"
+
       - name: Azure Login
         uses: azure/login@v2
         with:
-          creds: |
-            {
-              "clientId": "${{ secrets.AZURE_CLIENT_ID }}",
-              "clientSecret": "${{ secrets.AZURE_CLIENT_SECRET }}",
-              "tenantId": "${{ secrets.AZURE_TENANT_ID }}",
-              "subscriptionId": "${{ secrets.AZURE_SUBSCRIPTION_ID }}"
-            }
+          creds: ${{ env.AZURE_CREDENTIALS }}
 
       - name: Update Azure RBAC data
         run: npm run update-rbac-data

--- a/.github/workflows/update-ip-data.yml
+++ b/.github/workflows/update-ip-data.yml
@@ -8,8 +8,8 @@ on:
     # Allow manual triggering
 
 # This workflow updates both Azure IP ranges and RBAC role definitions
-# Required GitHub Secret: AZURE_CREDENTIALS (JSON format for Azure CLI login)
-# Format: {"clientId":"...","clientSecret":"...","subscriptionId":"...","tenantId":"..."}
+# Required GitHub Secrets:
+#   AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_TENANT_ID, AZURE_SUBSCRIPTION_ID
 # The service principal needs read permissions on role definitions
 
 jobs:
@@ -17,6 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write  # This is crucial for allowing the workflow to push changes
+    env:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
     steps:
       - name: Checkout repository
@@ -42,15 +47,13 @@ jobs:
       - name: Azure Login
         uses: azure/login@v2
         with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
-
-      - name: Export Azure service principal credentials
-        run: |
-          echo '${{ secrets.AZURE_CREDENTIALS }}' > azure-credentials.json
-          echo "AZURE_CLIENT_ID=$(node -p "JSON.parse(require('fs').readFileSync('azure-credentials.json', 'utf8')).clientId")" >> $GITHUB_ENV
-          echo "AZURE_CLIENT_SECRET=$(node -p "JSON.parse(require('fs').readFileSync('azure-credentials.json', 'utf8')).clientSecret")" >> $GITHUB_ENV
-          echo "AZURE_TENANT_ID=$(node -p "JSON.parse(require('fs').readFileSync('azure-credentials.json', 'utf8')).tenantId")" >> $GITHUB_ENV
-          rm azure-credentials.json
+          creds: |
+            {
+              "clientId": "${{ secrets.AZURE_CLIENT_ID }}",
+              "clientSecret": "${{ secrets.AZURE_CLIENT_SECRET }}",
+              "tenantId": "${{ secrets.AZURE_TENANT_ID }}",
+              "subscriptionId": "${{ secrets.AZURE_SUBSCRIPTION_ID }}"
+            }
 
       - name: Update Azure RBAC data
         run: npm run update-rbac-data


### PR DESCRIPTION
The AZURE_CREDENTIALS JSON-blob secret was removed during the Cloudflare
migration, which made azure/login@v2 fail with "Not all values are present.
Ensure 'client-id' and 'tenant-id' are supplied." Build the creds JSON from
the individual AZURE_* secrets that already exist (matching deploy-cloudflare.yml)
and drop the now-redundant step that re-extracted them into env vars.

https://claude.ai/code/session_01WmpXQEJoLnDJgkJ7neqwhi