### PR TITLE
fix(ci): restore service-principal login for Update Azure Data workflow

### DIFF
--- a/.github/workflows/update-ip-data.yml
+++ b/.github/workflows/update-ip-data.yml
@@ -22,6 +22,7 @@ jobs:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
     steps:
       - name: Checkout repository
@@ -44,12 +45,23 @@ jobs:
       - name: Update Private DNS zone data
         run: npm run update-private-dns-zones
 
+      - name: Build Azure credentials JSON
+        run: |
+          creds=$(jq -nc \
+            --arg cid "$AZURE_CLIENT_ID" \
+            --arg cs  "$AZURE_CLIENT_SECRET" \
+            --arg tid "$AZURE_TENANT_ID" \
+            --arg sid "$AZURE_SUBSCRIPTION_ID" \
+            '{clientId:$cid, clientSecret:$cs, tenantId:$tid, subscriptionId:$sid}')
+          echo "::add-mask::$creds"
+          echo "AZURE_CREDENTIALS<<EOF" >> "$GITHUB_ENV"
+          echo "$creds" >> "$GITHUB_ENV"
+          echo "EOF" >> "$GITHUB_ENV"
+
       - name: Azure Login
         uses: azure/login@v2
         with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          creds: ${{ env.AZURE_CREDENTIALS }}
 
       - name: Update Azure RBAC data
         run: npm run update-rbac-data


### PR DESCRIPTION
## Summary

- PR #137 switched `azure/login@v2` to OIDC-style inputs (`client-id` / `tenant-id` / `subscription-id` with no `creds`), which triggers the federated-token code path. That fails with `Failed to fetch federated token from GitHub` / `Unable to get ACTIONS_ID_TOKEN_REQUEST_URL` because this repo has no `id-token: write` permission and no federated credential configured on the Azure app registration.
- This PR switches back to service-principal-with-secret auth using the `AZURE_CLIENT_SECRET` that already exists in repo secrets.
- The `creds` JSON is built with `jq` in a preceding step so special characters in the secret can't break JSON parsing. The value is masked and passed to `azure/login` via `$GITHUB_ENV`.

## Required secrets (unchanged from main)

- `AZURE_CLIENT_ID`
- `AZURE_CLIENT_SECRET`
- `AZURE_TENANT_ID`
- `AZURE_SUBSCRIPTION_ID`

## Test plan

- [ ] After merge, trigger the workflow via **Actions → Update Azure Data → Run workflow**.
- [ ] Confirm the `Azure Login` step succeeds.
- [ ] Confirm `Update Azure RBAC data` and `Update Entra ID roles data` steps complete.

https://claude.ai/code/session_01WmpXQEJoLnDJgkJ7neqwhi