### PR TITLE
fix(mobile): prevent service-tag page from auto-zooming and polish sidebar drawer

### DIFF
--- a/src/components/Results.tsx
+++ b/src/components/Results.tsx
@@ -475,41 +475,41 @@ const Results = memo(function Results({ results, query, total, hideCloudFilter, 
       </header>
 
       <div className="w-full overflow-x-auto">
-        <table className="relative w-full min-w-[800px] table-auto divide-y divide-slate-200 dark:divide-slate-700" aria-label="Azure IP Ranges">
+        <table className="relative w-full min-w-full table-auto divide-y divide-slate-200 md:min-w-[800px] dark:divide-slate-700" aria-label="Azure IP Ranges">
           <thead className="bg-slate-100 dark:bg-slate-900/60">
             <tr className="text-left text-xs uppercase tracking-wider text-slate-500 dark:text-slate-400">
               <th
-                className="w-[8%] px-5 py-4 font-semibold transition hover:bg-slate-200 dark:hover:bg-slate-800"
+                className="hidden w-[8%] px-5 py-4 font-semibold transition hover:bg-slate-200 md:table-cell dark:hover:bg-slate-800"
                 onClick={() => handleSort('cloud')}
               >
                 Cloud {renderSortIndicator('cloud')}
               </th>
               <th
-                className="w-[18%] px-5 py-4 font-semibold transition hover:bg-slate-200 dark:hover:bg-slate-800"
+                className="w-[30%] px-3 py-3 font-semibold transition hover:bg-slate-200 md:w-[18%] md:px-5 md:py-4 dark:hover:bg-slate-800"
                 onClick={() => handleSort('serviceTagId')}
               >
                 Service Tag {renderSortIndicator('serviceTagId')}
               </th>
               <th
-                className="w-[20%] px-5 py-4 font-semibold transition hover:bg-slate-200 dark:hover:bg-slate-800"
+                className="w-[35%] px-3 py-3 font-semibold transition hover:bg-slate-200 md:w-[20%] md:px-5 md:py-4 dark:hover:bg-slate-800"
                 onClick={() => handleSort('ipAddressPrefix')}
               >
                 IP Range {renderSortIndicator('ipAddressPrefix')}
               </th>
               <th
-                className="w-[15%] px-5 py-4 font-semibold transition hover:bg-slate-200 dark:hover:bg-slate-800"
+                className="hidden w-[15%] px-5 py-4 font-semibold transition hover:bg-slate-200 lg:table-cell dark:hover:bg-slate-800"
                 onClick={() => handleSort('region')}
               >
                 Region {renderSortIndicator('region')}
               </th>
               <th
-                className="w-[20%] px-5 py-4 font-semibold transition hover:bg-slate-200 dark:hover:bg-slate-800"
+                className="w-[35%] px-3 py-3 font-semibold transition hover:bg-slate-200 md:w-[20%] md:px-5 md:py-4 dark:hover:bg-slate-800"
                 onClick={() => handleSort('systemService')}
               >
                 System Service {renderSortIndicator('systemService')}
               </th>
               <th
-                className="relative w-[25%] px-5 py-4 font-semibold transition hover:bg-slate-200 dark:hover:bg-slate-800"
+                className="relative hidden w-[25%] px-5 py-4 font-semibold transition hover:bg-slate-200 lg:table-cell dark:hover:bg-slate-800"
                 onClick={() => handleSort('networkFeatures')}
               >
                 <div className="flex items-center gap-2">
@@ -538,25 +538,25 @@ const Results = memo(function Results({ results, query, total, hideCloudFilter, 
                 key={`${result.serviceTagId}-${result.ipAddressPrefix}-${index}`}
                 className={index % 2 === 0 ? 'bg-white dark:bg-slate-900' : 'bg-slate-50 dark:bg-slate-900/70'}
               >
-                <td className="px-5 py-4 text-sm">
+                <td className="hidden px-5 py-4 text-sm md:table-cell">
                   {result.cloud && (
                     <span className={`inline-block rounded-md px-2 py-0.5 text-xs font-medium ${CLOUD_STYLES[result.cloud]}`}>
                       {CLOUD_LABELS[result.cloud]}
                     </span>
                   )}
                 </td>
-                <td className="px-5 py-4 text-sm font-semibold text-slate-900 dark:text-slate-100">
+                <td className="px-3 py-3 text-sm font-semibold text-slate-900 md:px-5 md:py-4 dark:text-slate-100">
                   <button
                     onClick={() => handleServiceTagClick(result.serviceTagId)}
                     className="rounded-md border border-transparent px-2 py-1 text-left text-sky-600 transition hover:border-sky-200 hover:bg-sky-100 hover:text-sky-700 dark:text-sky-300 dark:hover:border-sky-800 dark:hover:bg-sky-900/20 dark:hover:text-sky-200"
                     title={`View details for ${result.serviceTagId}`}
                   >
-                    {result.serviceTagId}
+                    <span className="break-all">{result.serviceTagId}</span>
                   </button>
                 </td>
-                <td className="px-5 py-4 font-mono text-sm text-slate-900 dark:text-slate-100">
+                <td className="px-3 py-3 font-mono text-sm text-slate-900 md:px-5 md:py-4 dark:text-slate-100">
                   <div className="space-y-2">
-                    <div>{result.ipAddressPrefix}</div>
+                    <div className="break-all">{result.ipAddressPrefix}</div>
                     {result.resolvedFrom && result.resolvedIp && (
                       <div className="space-y-1">
                         <span className="inline-block rounded-md border border-emerald-200 bg-emerald-50 px-2 py-1 text-xs font-semibold text-emerald-700 dark:border-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-200">
@@ -571,9 +571,15 @@ const Results = memo(function Results({ results, query, total, hideCloudFilter, 
                     )}
                   </div>
                 </td>
-                <td className="px-5 py-4 text-sm text-slate-600 dark:text-slate-300">{result.region || '-'}</td>
-                <td className="px-5 py-4 text-sm text-slate-600 dark:text-slate-300">{result.systemService || '-'}</td>
-                <td className="px-5 py-4 text-sm text-slate-600 dark:text-slate-300">{result.networkFeatures || '-'}</td>
+                <td className="hidden px-5 py-4 text-sm text-slate-600 lg:table-cell dark:text-slate-300">{result.region || '-'}</td>
+                <td className="px-3 py-3 text-sm text-slate-600 md:px-5 md:py-4 dark:text-slate-300">
+                  <div className="break-words">{result.systemService || '-'}</div>
+                  <div className="mt-1 text-xs text-slate-400 lg:hidden dark:text-slate-500">
+                    {result.region && <span className="mr-2">Region: {result.region}</span>}
+                    {result.networkFeatures && <span>{result.networkFeatures}</span>}
+                  </div>
+                </td>
+                <td className="hidden px-5 py-4 text-sm text-slate-600 lg:table-cell dark:text-slate-300">{result.networkFeatures || '-'}</td>
               </tr>
             ))}
           </tbody>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -45,15 +45,15 @@ export function Sidebar({
 
       {/* Sidebar */}
       <aside
-        className={`relative flex flex-col border-r border-slate-200 bg-[#F3F4F6]/95 backdrop-blur transition-all duration-200 ease-out dark:border-[#363638] dark:bg-[#1B1B1C]/95 ${
-          isSidebarCollapsed ? 'w-20' : 'w-72'
-        } ${
-          isMobileMenuOpen ? 'fixed inset-y-0 left-0 z-50 md:relative' : 'hidden md:flex'
-        }`}
+        className={`flex-col border-r border-slate-200 bg-[#F3F4F6]/95 backdrop-blur transition-all duration-200 ease-out dark:border-[#363638] dark:bg-[#1B1B1C]/95 ${
+          isMobileMenuOpen
+            ? 'fixed inset-y-0 left-0 z-50 flex w-[85vw] max-w-sm md:relative md:max-w-none'
+            : 'relative hidden md:flex'
+        } ${isSidebarCollapsed ? 'md:w-20' : 'md:w-72'}`}
       >
         <div className="flex items-center justify-between gap-3 px-4 py-5">
-          <Link href="/" className="flex items-center gap-3" aria-label="Azure Hub home">
-            <span className="flex h-10 w-10 items-center justify-center overflow-hidden rounded-xl">
+          <Link href="/" className="flex min-w-0 items-center gap-3" aria-label="Azure Hub home">
+            <span className="flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-xl">
               <Image
                 src="/favicons/favicon-32x32.png"
                 alt="Azure Hub logo"
@@ -63,13 +63,32 @@ export function Sidebar({
                 unoptimized
               />
             </span>
-            <span className={`text-lg font-semibold tracking-tight ${isSidebarCollapsed ? 'hidden' : 'block'}`}>
+            <span className={`whitespace-nowrap text-lg font-semibold tracking-tight ${isSidebarCollapsed ? 'md:hidden' : 'block'}`}>
               Azure Hub
             </span>
           </Link>
+          {/* Mobile close button */}
           <button
             type="button"
-            className="flex h-10 w-10 items-center justify-center rounded-md border border-slate-200 bg-white text-slate-500 shadow-sm transition hover:border-slate-300 hover:text-slate-700 dark:border-[#363638] dark:bg-[#2C2C2E] dark:text-slate-200 dark:hover:border-[#363638] dark:hover:text-slate-100"
+            className="flex h-10 w-10 items-center justify-center rounded-md border border-slate-200 bg-white text-slate-500 shadow-sm transition hover:border-slate-300 hover:text-slate-700 md:hidden dark:border-[#363638] dark:bg-[#2C2C2E] dark:text-slate-200 dark:hover:border-[#363638] dark:hover:text-slate-100"
+            onClick={onMobileMenuClose}
+            aria-label="Close navigation menu"
+          >
+            <svg
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+              className="h-5 w-5 text-current"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 6l12 12M18 6L6 18" />
+            </svg>
+          </button>
+          {/* Desktop collapse/expand button */}
+          <button
+            type="button"
+            className="hidden h-10 w-10 items-center justify-center rounded-md border border-slate-200 bg-white text-slate-500 shadow-sm transition hover:border-slate-300 hover:text-slate-700 md:flex dark:border-[#363638] dark:bg-[#2C2C2E] dark:text-slate-200 dark:hover:border-[#363638] dark:hover:text-slate-100"
             onClick={() => setIsSidebarCollapsed((prev) => !prev)}
             aria-pressed={isSidebarCollapsed}
             aria-label={isSidebarCollapsed ? 'Expand navigation' : 'Collapse navigation'}
@@ -100,7 +119,7 @@ export function Sidebar({
             const active = matchRoute(item.href);
             const disabled = item.disabled;
             const baseClasses =
-              'group flex items-center gap-2 rounded-lg px-3 py-1.5 text-sm font-medium transition-colors';
+              'group flex items-center gap-2 rounded-lg px-3 py-2 text-base font-medium transition-colors md:py-1.5 md:text-sm';
             const stateClasses = disabled
               ? 'cursor-not-allowed text-slate-300 dark:text-slate-700'
               : active
@@ -116,8 +135,9 @@ export function Sidebar({
                 tabIndex={disabled ? -1 : undefined}
                 onClick={(event) => {
                   if (disabled) {
-                    event.preventDefault();
+                    return event.preventDefault();
                   }
+                  onMobileMenuClose();
                 }}
               >
                 <span
@@ -125,9 +145,9 @@ export function Sidebar({
                 >
                   {ICONS[item.icon](active)}
                 </span>
-                <span className={`${isSidebarCollapsed ? 'hidden' : 'block'}`}>{item.label}</span>
+                <span className={`whitespace-nowrap ${isSidebarCollapsed ? 'md:hidden' : 'block'}`}>{item.label}</span>
                 {item.comingSoon && !isSidebarCollapsed && (
-                  <span className="ml-auto text-xs font-semibold uppercase text-slate-400 dark:text-slate-500">
+                  <span className="ml-auto whitespace-nowrap text-xs font-semibold uppercase text-slate-400 dark:text-slate-500">
                     Soon
                   </span>
                 )}


### PR DESCRIPTION
The service-tag detail table forced a fixed 800px min-width, which made
mobile Safari shrink the entire page to fit. Drop the fixed min-width on
small screens, hide the lower-priority Cloud/Region/Network Features
columns below lg, and fold Region + Network Features under System Service
so nothing is lost. Tighten cell padding on mobile.

Rework the sidebar drawer for mobile: widen to 85vw (max 24rem) so labels
like "Private DNS Zones" no longer wrap, hide the desktop collapse chevron
on mobile and expose a proper close (X) button, bump nav item touch targets
on mobile, keep labels on one line with whitespace-nowrap, and auto-close
the drawer when a link is tapped.

https://claude.ai/code/session_01VixvgRTK22VFwAXUhRaL2D