### PR TITLE
Persist empty diffs and show UI message for version-only updates

### DIFF
--- a/scripts/computeIpDiff.ts
+++ b/scripts/computeIpDiff.ts
@@ -47,37 +47,32 @@ export function computeIpDiff(options: ComputeDiffOptions): IpDiffFile {
         ...(cloud && { cloud }),
       });
     } else {
-      // Check if tag was modified (changeNumber changed)
-      if (
-        previousTag.properties.changeNumber !== currentTag.properties.changeNumber
-      ) {
-        const previousPrefixes = new Set(
-          previousTag.properties.addressPrefixes || []
-        );
-        const currentPrefixes = new Set(
-          currentTag.properties.addressPrefixes || []
-        );
+      const previousPrefixes = new Set(
+        previousTag.properties.addressPrefixes || []
+      );
+      const currentPrefixes = new Set(
+        currentTag.properties.addressPrefixes || []
+      );
 
-        const addedPrefixes = [...currentPrefixes].filter(
-          (p) => !previousPrefixes.has(p)
-        );
-        const removedPrefixes = [...previousPrefixes].filter(
-          (p) => !currentPrefixes.has(p)
-        );
+      const addedPrefixes = [...currentPrefixes].filter(
+        (p) => !previousPrefixes.has(p)
+      );
+      const removedPrefixes = [...previousPrefixes].filter(
+        (p) => !currentPrefixes.has(p)
+      );
 
-        // Only include if there are actual prefix changes
-        if (addedPrefixes.length > 0 || removedPrefixes.length > 0) {
-          modifiedTags.push({
-            name: currentTag.name,
-            systemService: currentTag.properties.systemService || '',
-            region: currentTag.properties.region || '',
-            previousChangeNumber: previousTag.properties.changeNumber || 0,
-            currentChangeNumber: currentTag.properties.changeNumber || 0,
-            addedPrefixes,
-            removedPrefixes,
-            ...(cloud && { cloud }),
-          });
-        }
+      // Only include if there are actual prefix changes
+      if (addedPrefixes.length > 0 || removedPrefixes.length > 0) {
+        modifiedTags.push({
+          name: currentTag.name,
+          systemService: currentTag.properties.systemService || '',
+          region: currentTag.properties.region || '',
+          previousChangeNumber: previousTag.properties.changeNumber || 0,
+          currentChangeNumber: currentTag.properties.changeNumber || 0,
+          addedPrefixes,
+          removedPrefixes,
+          ...(cloud && { cloud }),
+        });
       }
     }
   }

--- a/scripts/updateIpData.ts
+++ b/scripts/updateIpData.ts
@@ -128,6 +128,35 @@ function saveMetadata(metadata: AzureFileMetadata[]): void {
   }
 }
 
+function createNoChangesDiff(metadata: AzureFileMetadata[]): IpDiffFile {
+  const clouds = metadata.reduce<NonNullable<IpDiffFile['meta']['clouds']>>((acc, item) => {
+    acc[item.cloud] = {
+      fromChangeNumber: item.changeNumber,
+      toChangeNumber: item.changeNumber,
+      fromFilename: item.filename,
+      toFilename: item.filename,
+    };
+    return acc;
+  }, {});
+
+  return {
+    meta: {
+      generatedAt: new Date().toISOString(),
+      summary: {
+        serviceTagsAdded: 0,
+        serviceTagsRemoved: 0,
+        serviceTagsModified: 0,
+        totalPrefixesAdded: 0,
+        totalPrefixesRemoved: 0,
+      },
+      clouds,
+    },
+    addedTags: [],
+    removedTags: [],
+    modifiedTags: [],
+  };
+}
+
 /**
  * Selects the most specific link based on URL length.
  */
@@ -415,18 +444,24 @@ async function updateAllIpData(): Promise<void> {
       if (currentVersionData) {
         const previousDataPath = path.join(DATA_DIR, `${mapping.cloud}-previous.json`);
 
-        // If the changeNumber is different, compute diff
-        if (currentVersionData.changeNumber !== data.changeNumber) {
-          console.info(`[${mapping.cloud}] Computing diff: changeNumber ${currentVersionData.changeNumber} → ${data.changeNumber}`);
+        const previousMeta = existingMetadata || { filename: 'unknown.json' };
+        const diff = computeIpDiff({
+          previousData: currentVersionData,
+          currentData: data,
+          previousFilename: previousMeta.filename,
+          currentFilename: filename,
+          cloud: mapping.cloud,
+        });
 
-          const previousMeta = existingMetadata || { filename: 'unknown.json' };
-          const diff = computeIpDiff({
-            previousData: currentVersionData,
-            currentData: data,
-            previousFilename: previousMeta.filename,
-            currentFilename: filename,
-            cloud: mapping.cloud,
-          });
+        const hasContentChanges =
+          diff.meta.summary.serviceTagsAdded > 0 ||
+          diff.meta.summary.serviceTagsRemoved > 0 ||
+          diff.meta.summary.serviceTagsModified > 0;
+
+        const hasVersionChange = currentVersionData.changeNumber !== data.changeNumber;
+
+        if (hasVersionChange || hasContentChanges) {
+          console.info(`[${mapping.cloud}] Computing diff: changeNumber ${currentVersionData.changeNumber} → ${data.changeNumber}`);
 
           // Add to collection for later merging
           cloudDiffs.push(diff);
@@ -442,7 +477,7 @@ async function updateAllIpData(): Promise<void> {
           fs.writeFileSync(previousDataPath, JSON.stringify(currentVersionData, null, 2), 'utf8');
           console.info(`[${mapping.cloud}] Archived previous version to ${previousDataPath}`);
         } else {
-          console.info(`[${mapping.cloud}] No changes detected (changeNumber: ${data.changeNumber})`);
+          console.info(`[${mapping.cloud}] No version or prefix changes detected (changeNumber: ${data.changeNumber})`);
         }
       }
 
@@ -476,16 +511,17 @@ async function updateAllIpData(): Promise<void> {
   }
 
   // Merge all cloud diffs and save combined diff file
-  if (cloudDiffs.length > 0) {
-    const mergedDiff = mergeDiffs(cloudDiffs);
-    fs.writeFileSync(DIFF_FILE, JSON.stringify(mergedDiff, null, 2), 'utf8');
-    console.info(`Saved merged diff to ${DIFF_FILE}`);
-    console.info(`  Combined summary: +${mergedDiff.meta.summary.totalPrefixesAdded} prefixes, -${mergedDiff.meta.summary.totalPrefixesRemoved} prefixes across ${cloudDiffs.length} cloud(s)`);
-    console.info(`  ${mergedDiff.meta.summary.serviceTagsAdded} tags added, ${mergedDiff.meta.summary.serviceTagsRemoved} removed, ${mergedDiff.meta.summary.serviceTagsModified} modified`);
-  }
-
   // Save updated metadata
   saveMetadata(metadata);
+
+  const diffToPersist = cloudDiffs.length > 0
+    ? mergeDiffs(cloudDiffs)
+    : createNoChangesDiff(metadata);
+
+  fs.writeFileSync(DIFF_FILE, JSON.stringify(diffToPersist, null, 2), 'utf8');
+  console.info(`Saved diff to ${DIFF_FILE}`);
+  console.info(`  Combined summary: +${diffToPersist.meta.summary.totalPrefixesAdded} prefixes, -${diffToPersist.meta.summary.totalPrefixesRemoved} prefixes across ${cloudDiffs.length} cloud(s)`);
+  console.info(`  ${diffToPersist.meta.summary.serviceTagsAdded} tags added, ${diffToPersist.meta.summary.serviceTagsRemoved} removed, ${diffToPersist.meta.summary.serviceTagsModified} modified`);
 
   // Regenerate the IP lookup index for binary search
   console.info('\nRegenerating IP lookup index...');

--- a/src/components/RecentChangesCard.tsx
+++ b/src/components/RecentChangesCard.tsx
@@ -137,6 +137,11 @@ export default function RecentChangesCard() {
 
       {/* Footer stats */}
       <div className="px-5 pb-4 pt-1">
+        {summary && summary.serviceTagsAdded === 0 && summary.serviceTagsRemoved === 0 && summary.serviceTagsModified === 0 && (
+          <p className="text-[11px] text-slate-400 dark:text-slate-500">
+            Version updated, but no IP prefix changes were published in this update.
+          </p>
+        )}
         {summary && (summary.serviceTagsAdded > 0 || summary.serviceTagsModified > 0) && (
           <p className="text-[11px] text-slate-400 dark:text-slate-500">
             {summary.serviceTagsAdded > 0 && <>{summary.serviceTagsAdded} new service tags</>}

--- a/src/pages/tools/ip-changes.tsx
+++ b/src/pages/tools/ip-changes.tsx
@@ -168,7 +168,8 @@ export default function IpChangesPage() {
 
             {totalChanges === 0 && (
               <div className="rounded-xl bg-white p-6 text-sm text-slate-500 dark:bg-slate-900 dark:text-slate-400">
-                No changes found for this cloud.
+                No IP prefix changes were found for this cloud/version selection. Microsoft sometimes increments
+                the weekly Service Tags version without changing published address prefixes.
               </div>
             )}
           </>


### PR DESCRIPTION
### Motivation
- Ensure the system records and surfaces Microsoft Service Tags updates even when the published IP prefixes did not change but the `changeNumber` did.
- Provide clear UI feedback when a version increment occurs without any address prefix changes.

### Description
- Always compute prefix-level diffs between previous and current service tag data and determine whether there are content changes, removing the prior guard that skipped diffing based solely on `changeNumber`.
- Add `createNoChangesDiff` and persist a merged diff file even when no clouds report prefix changes so metadata and cloud version info are still exposed in `DIFF_FILE`.
- Update logging in `updateIpData.ts` to reflect detection of version or prefix changes and archive previous data when a diff is produced.
- Improve frontend messaging by adding a notice in `RecentChangesCard` and clarifying the no-changes panel in `ip-changes.tsx` when a version bump occurs without IP prefix changes.

### Testing
- Ran TypeScript type-check with `tsc --noEmit`, which completed successfully.
- Performed a project build with `next build`, which succeeded.
- Ran linter with `npm run lint`, which reported no new issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f0fabba93883318ea42c790b24d573)