### PR TITLE
ci: dispatch Cloudflare deploy after data update commits

### DIFF
--- a/.github/workflows/update-ip-data.yml
+++ b/.github/workflows/update-ip-data.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write  # This is crucial for allowing the workflow to push changes
+      actions: write   # Needed to dispatch the Cloudflare deploy workflow after pushing
     env:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
@@ -77,6 +78,12 @@ jobs:
           git add -A
           git status
           git diff --staged --quiet && echo "changes=false" >> $GITHUB_OUTPUT || (git commit -m "chore: update Azure IP and RBAC data" && git push && echo "changes=true" >> $GITHUB_OUTPUT)
+
+      - name: Trigger Cloudflare deploy
+        if: steps.commit.outputs.changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run deploy-cloudflare.yml --ref main
 
       - name: Submit URLs to IndexNow
         if: steps.commit.outputs.changes == 'true'


### PR DESCRIPTION
The daily data update commits to main using GITHUB_TOKEN, which by
design does not trigger downstream workflow runs. As a result the
Cloudflare deploy workflow has not been firing on any bot commit, and
the deployed site has been stuck at whichever build corresponds to the
last human push - even though file-metadata.json on main is fresh.

workflow_dispatch is the documented exception to the GITHUB_TOKEN
cascade rule, so explicitly dispatching deploy-cloudflare.yml with the
gh CLI is enough to kick the deploy. Gated on the existing changes=true
output so no-op runs do not redeploy. actions: write is added to the
job permissions so the dispatch call has the scope it needs.