### PR TITLE
fix(seo): consolidate regional service-tag variants into base pages

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -93,6 +93,14 @@ const nextConfig = {
         permanent: true,
       },
       {
+        // Regional service-tag variants (e.g. /tools/service-tags/Storage.WestEurope) are
+        // consolidated into the base tag page as a region filter. Redirect any tag segment
+        // containing a dot to its base page. ":base" captures the name up to the first dot.
+        source: '/tools/service-tags/:base([^/.]+).:rest(.*)',
+        destination: '/tools/service-tags/:base/',
+        permanent: true,
+      },
+      {
         source: '/service-tags',
         destination: '/tools/service-tags/',
         permanent: true,

--- a/scripts/generateSiteData.ts
+++ b/scripts/generateSiteData.ts
@@ -289,9 +289,9 @@ function buildServiceTagSummary() {
   const tagSet = new Set<string>();
 
   for (const entry of index) {
-    if (!entry.id.includes('.')) {
-      tagSet.add(entry.id);
-    }
+    // Base tag = part before the first dot. Sub-tags are consolidated into the base page,
+    // and this also covers families like AzureFrontDoor that have no global entry.
+    tagSet.add(entry.id.split('.')[0]);
   }
 
   return {

--- a/scripts/generateSitemap.js
+++ b/scripts/generateSitemap.js
@@ -62,8 +62,10 @@ function getBaseServiceTags() {
     const index = JSON.parse(fs.readFileSync(indexPath, 'utf8'));
     const baseTags = new Set();
     for (const entry of index) {
-      if (entry && typeof entry.id === 'string' && !entry.id.includes('.')) {
-        baseTags.add(entry.id);
+      if (entry && typeof entry.id === 'string') {
+        // Use the base tag (part before the first dot). Sub-tags are consolidated into it,
+        // and this also covers families like AzureFrontDoor that have no global entry.
+        baseTags.add(entry.id.split('.')[0]);
       }
     }
     return Array.from(baseTags).sort();

--- a/src/generated/site-data.json
+++ b/src/generated/site-data.json
@@ -1,45 +1,36 @@
 {
   "home": {
-    "lastUpdated": "2026-05-08"
+    "lastUpdated": "2026-06-04"
   },
   "about": {
     "fileMetadata": [
       {
         "cloud": "AzureCloud",
-        "changeNumber": 399,
-        "filename": "ServiceTags_Public_20260504.json",
-        "downloadUrl": "https://download.microsoft.com/download/7/1/d/71d86715-5596-4529-9b13-da13a5de5b63/ServiceTags_Public_20260504.json",
-        "lastRetrieved": "2026-05-08",
-        "previousChangeNumber": 398,
-        "previousFilename": "ServiceTags_Public_20260427.json",
-        "diffAvailable": true
+        "changeNumber": 402,
+        "filename": "ServiceTags_Public_20260525.json",
+        "downloadUrl": "https://download.microsoft.com/download/7/1/d/71d86715-5596-4529-9b13-da13a5de5b63/ServiceTags_Public_20260525.json",
+        "lastRetrieved": "2026-06-04"
       },
       {
         "cloud": "AzureChinaCloud",
-        "changeNumber": 394,
-        "filename": "ServiceTags_China_20260504.json",
-        "downloadUrl": "https://download.microsoft.com/download/9/d/0/9d03b7e2-4b80-4bf3-9b91-da8c7d3ee9f9/ServiceTags_China_20260504.json",
-        "lastRetrieved": "2026-05-08",
-        "previousChangeNumber": 393,
-        "previousFilename": "ServiceTags_China_20260427.json",
-        "diffAvailable": true
+        "changeNumber": 397,
+        "filename": "ServiceTags_China_20260525.json",
+        "downloadUrl": "https://download.microsoft.com/download/9/d/0/9d03b7e2-4b80-4bf3-9b91-da8c7d3ee9f9/ServiceTags_China_20260525.json",
+        "lastRetrieved": "2026-06-04"
       },
       {
         "cloud": "AzureUSGovernment",
-        "changeNumber": 391,
-        "filename": "ServiceTags_AzureGovernment_20260504.json",
-        "downloadUrl": "https://download.microsoft.com/download/6/4/d/64db03bf-895b-4173-a8b1-ba4ad5d4df22/ServiceTags_AzureGovernment_20260504.json",
-        "lastRetrieved": "2026-05-08",
-        "previousChangeNumber": 390,
-        "previousFilename": "ServiceTags_AzureGovernment_20260323.json",
-        "diffAvailable": true
+        "changeNumber": 394,
+        "filename": "ServiceTags_AzureGovernment_20260525.json",
+        "downloadUrl": "https://download.microsoft.com/download/6/4/d/64db03bf-895b-4173-a8b1-ba4ad5d4df22/ServiceTags_AzureGovernment_20260525.json",
+        "lastRetrieved": "2026-06-04"
       }
     ],
-    "rbacLastRetrieved": "2026-05-08"
+    "rbacLastRetrieved": "2026-06-04"
   },
   "rbac": {
-    "roleCount": 880,
-    "namespaceCount": 235
+    "roleCount": 893,
+    "namespaceCount": 237
   },
   "entraid": {
     "roleCount": 0,
@@ -74,6 +65,7 @@
       "AzureDeviceUpdate",
       "AzureDigitalTwins",
       "AzureEventGrid",
+      "AzureFrontDoor",
       "AzureHealthcareAPIs",
       "AzureInformationProtection",
       "AzureIoTHub",

--- a/src/lib/serviceTagUrl.ts
+++ b/src/lib/serviceTagUrl.ts
@@ -1,13 +1,17 @@
 /**
- * Next.js treats path segments containing dots as file-like and normalizes them
- * without a trailing slash. Keep URL generation aligned to avoid redirect chains.
+ * Regional service-tag variants (e.g. "Storage.WestEurope") no longer have their own
+ * pages. They are consolidated into the base tag page ("Storage") as a region filter,
+ * so every tag ID — base or regional — resolves to its base page URL. Base tag names
+ * never contain a dot, so the URL always carries a trailing slash (matching the global
+ * trailingSlash config and avoiding redirect chains).
  */
+export function getServiceTagBaseId(serviceTag: string): string {
+  return serviceTag.split('.')[0];
+}
+
 export function getServiceTagPath(serviceTag: string): string {
-  const encodedTag = encodeURIComponent(serviceTag);
-  const hasDot = serviceTag.includes('.');
-  return hasDot
-    ? `/tools/service-tags/${encodedTag}`
-    : `/tools/service-tags/${encodedTag}/`;
+  const baseId = getServiceTagBaseId(serviceTag);
+  return `/tools/service-tags/${encodeURIComponent(baseId)}/`;
 }
 
 export function getServiceTagCanonicalUrl(serviceTag: string): string {

--- a/src/pages/tools/service-tags/[serviceTag].tsx
+++ b/src/pages/tools/service-tags/[serviceTag].tsx
@@ -11,9 +11,9 @@ import ErrorBox from '@/components/shared/ErrorBox';
 
 interface ServiceTagDetailProps {
   serviceTag: string;
-  isBaseTag: boolean;
   ipRanges: AzureIpAddress[];
   cloudsCovered: AzureCloudName[];
+  regions: string[];
 }
 
 const DEFAULT_PAGE_SIZE = 100;
@@ -43,16 +43,23 @@ const CLOUD_LABELS: Record<string, string> = {
   [AzureCloudName.AzureUSGovernment]: 'Azure Government'
 };
 
-// Build-time only. Indexes every service tag to its IP prefixes across all clouds,
-// cached at module scope so the (large) cloud JSON files are read once per build
-// worker instead of once per generated page. Referenced only from getStaticProps,
-// so Next.js strips this function and its fs/path usage from the client bundle.
+// Build-time only. Indexes every BASE service tag to the merged set of its IP prefixes:
+// the global entry (e.g. "Storage") plus every regional variant ("Storage.WestEurope").
+// Ranges are deduped per (cloud, prefix); a regional entry's region label wins over the
+// unlabeled global entry so the region filter works. Cached at module scope so the (large)
+// cloud JSON files are read once per build worker. Referenced only from getStaticProps, so
+// Next.js strips this function and its fs/path usage from the client bundle.
 let serviceTagMapCache: Map<string, AzureIpAddress[]> | null = null;
+
+function baseIdOf(name: string): string {
+  return name.split('.')[0];
+}
 
 function loadServiceTagMap(): Map<string, AzureIpAddress[]> {
   if (serviceTagMapCache) return serviceTagMapCache;
 
-  const map = new Map<string, AzureIpAddress[]>();
+  // base tag -> ("cloud|prefix" -> range), deduped with regional labels preferred
+  const byBase = new Map<string, Map<string, AzureIpAddress>>();
 
   for (const cloud of ALL_CLOUDS) {
     const filePath = path.join(process.cwd(), 'public', 'data', `${cloud}.json`);
@@ -64,44 +71,68 @@ function loadServiceTagMap(): Map<string, AzureIpAddress[]> {
     }
 
     for (const entry of data.values) {
-      const ranges = entry.properties.addressPrefixes.map((prefix) => ({
-        serviceTagId: entry.name,
-        ipAddressPrefix: prefix,
-        region: entry.properties.region || '',
-        regionId: entry.properties.regionId || '',
-        systemService: entry.properties.systemService || '',
-        networkFeatures: (entry.properties.networkFeatures || []).join(', '),
-        cloud
-      } satisfies AzureIpAddress));
+      const base = baseIdOf(entry.name);
+      const isRegional = entry.name.includes('.');
 
-      const existing = map.get(entry.name);
-      if (existing) {
-        existing.push(...ranges);
-      } else {
-        map.set(entry.name, ranges);
+      let deduped = byBase.get(base);
+      if (!deduped) {
+        deduped = new Map<string, AzureIpAddress>();
+        byBase.set(base, deduped);
+      }
+
+      for (const prefix of entry.properties.addressPrefixes) {
+        const key = `${cloud}|${prefix}`;
+        const record: AzureIpAddress = {
+          serviceTagId: base,
+          ipAddressPrefix: prefix,
+          region: entry.properties.region || '',
+          regionId: entry.properties.regionId || '',
+          systemService: entry.properties.systemService || '',
+          networkFeatures: (entry.properties.networkFeatures || []).join(', '),
+          cloud
+        };
+
+        const existing = deduped.get(key);
+        if (!existing) {
+          deduped.set(key, record);
+        } else if (isRegional && !existing.region) {
+          // Upgrade an unlabeled global prefix to its regional label
+          deduped.set(key, record);
+        }
       }
     }
   }
 
-  serviceTagMapCache = map;
-  return map;
+  serviceTagMapCache = new Map();
+  for (const [base, deduped] of byBase) {
+    serviceTagMapCache.set(base, Array.from(deduped.values()));
+  }
+  return serviceTagMapCache;
 }
 
-export default function ServiceTagDetail({ serviceTag, isBaseTag, ipRanges, cloudsCovered }: ServiceTagDetailProps) {
+export default function ServiceTagDetail({ serviceTag, ipRanges, cloudsCovered, regions }: ServiceTagDetailProps) {
   const [currentPage, setCurrentPage] = useState(1);
   const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
   const [isAll, setIsAll] = useState(false);
+  const [selectedRegion, setSelectedRegion] = useState<string>('all');
 
-  // Paginate the build-time data (no client fetch — the ranges ship in the HTML)
+  // Region filter is applied at the page level (before pagination) so it works across
+  // the full dataset rather than only the current page.
+  const filteredRanges = useMemo(() => {
+    if (selectedRegion === 'all') return ipRanges;
+    if (selectedRegion === 'global') return ipRanges.filter((r) => !r.region);
+    return ipRanges.filter((r) => r.region === selectedRegion);
+  }, [ipRanges, selectedRegion]);
+
   const paginatedResults = useMemo(() => {
-    if (ipRanges.length === 0) return [];
-    if (isAll) return ipRanges;
+    if (filteredRanges.length === 0) return [];
+    if (isAll) return filteredRanges;
 
     const startIndex = (currentPage - 1) * pageSize;
-    return ipRanges.slice(startIndex, startIndex + pageSize);
-  }, [ipRanges, currentPage, pageSize, isAll]);
+    return filteredRanges.slice(startIndex, startIndex + pageSize);
+  }, [filteredRanges, currentPage, pageSize, isAll]);
 
-  const totalPages = Math.ceil(ipRanges.length / pageSize);
+  const totalPages = Math.ceil(filteredRanges.length / pageSize);
 
   const handlePageSizeChange = (newPageSize: number | 'all') => {
     if (newPageSize === 'all') {
@@ -115,6 +146,12 @@ export default function ServiceTagDetail({ serviceTag, isBaseTag, ipRanges, clou
     }
   };
 
+  const handleRegionChange = (region: string) => {
+    setSelectedRegion(region);
+    setCurrentPage(1);
+    setIsAll(false);
+  };
+
   const canonicalUrl = getServiceTagCanonicalUrl(serviceTag);
 
   const breadcrumbs = [
@@ -125,7 +162,7 @@ export default function ServiceTagDetail({ serviceTag, isBaseTag, ipRanges, clou
 
   const cloudList = cloudsCovered.map((c) => CLOUD_LABELS[c] ?? c).join(', ');
   const summary = ipRanges.length > 0
-    ? `The ${serviceTag} service tag includes ${ipRanges.length.toLocaleString()} IP address ${ipRanges.length === 1 ? 'prefix' : 'prefixes'}${cloudList ? ` published across ${cloudList}` : ''}.`
+    ? `The ${serviceTag} service tag includes ${ipRanges.length.toLocaleString()} IP address ${ipRanges.length === 1 ? 'prefix' : 'prefixes'}${cloudList ? ` published across ${cloudList}` : ''}${regions.length > 0 ? `, spanning ${regions.length} Azure ${regions.length === 1 ? 'region' : 'regions'}` : ''}.`
     : 'IP ranges, Azure services, and network features associated with this service tag.';
 
   return (
@@ -134,7 +171,6 @@ export default function ServiceTagDetail({ serviceTag, isBaseTag, ipRanges, clou
       description={`View all IP ranges and CIDR prefixes for the Azure ${serviceTag} service tag, including regional breakdowns and address counts across all clouds.`}
       canonicalUrl={canonicalUrl}
       breadcrumbs={breadcrumbs}
-      noIndex={!isBaseTag}
     >
       <section className="space-y-8">
         <div className="space-y-2 md:space-y-3">
@@ -154,17 +190,38 @@ export default function ServiceTagDetail({ serviceTag, isBaseTag, ipRanges, clou
           </div>
         </div>
 
+        {/* Region filter — regional variants are consolidated here instead of separate pages */}
+        {regions.length > 0 && (
+          <div className="flex items-center gap-2">
+            <label htmlFor="region-filter" className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+              Region
+            </label>
+            <select
+              id="region-filter"
+              value={selectedRegion}
+              onChange={(e) => handleRegionChange(e.target.value)}
+              className="rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm text-slate-700 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/20 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200"
+            >
+              <option value="all">All regions</option>
+              <option value="global">Global (unscoped)</option>
+              {regions.map((region) => (
+                <option key={region} value={region}>{region}</option>
+              ))}
+            </select>
+          </div>
+        )}
+
         {/* Results — rendered from build-time data so the IP ranges are present in the HTML */}
-        {ipRanges.length > 0 ? (
+        {filteredRanges.length > 0 ? (
           <Results
             results={paginatedResults}
             query={serviceTag}
-            total={ipRanges.length}
+            total={filteredRanges.length}
             hideCloudFilter
             pagination={totalPages > 1 ? {
               currentPage,
               totalPages,
-              totalItems: ipRanges.length,
+              totalItems: filteredRanges.length,
               pageSize,
               isAll,
               onPageChange: (page) => {
@@ -181,7 +238,9 @@ export default function ServiceTagDetail({ serviceTag, isBaseTag, ipRanges, clou
           />
         ) : (
           <ErrorBox title="No results found">
-            This service tag exists, but no IP ranges are currently published for it.
+            {selectedRegion === 'all'
+              ? 'This service tag exists, but no IP ranges are currently published for it.'
+              : 'No IP ranges are published for this service tag in the selected region.'}
           </ErrorBox>
         )}
 
@@ -203,9 +262,10 @@ export const getStaticPaths: GetStaticPaths = async () => {
   try {
     const indexPath = path.join(process.cwd(), 'public', 'data', 'service-tags-index.json');
     const index = JSON.parse(fs.readFileSync(indexPath, 'utf8')) as Array<{ id: string }>;
-    const paths = Array.from(new Set(index.map((entry) => entry.id))).map((serviceTag) => ({
-      params: { serviceTag }
-    }));
+    // Only generate base tag pages. Regional variants (IDs with a dot) are consolidated
+    // into their base page and old variant URLs 301-redirect there (see next.config.js).
+    const baseTags = Array.from(new Set(index.map((entry) => entry.id))).filter((id) => !id.includes('.'));
+    const paths = baseTags.map((serviceTag) => ({ params: { serviceTag } }));
 
     return {
       paths,
@@ -224,17 +284,23 @@ export const getStaticProps: GetStaticProps<ServiceTagDetailProps> = async ({ pa
   }
 
   const serviceTag = decodeURIComponent(serviceTagParam);
+
+  // A regional variant should never reach here (redirected at the config level), but guard
+  // anyway so a stray dotted path doesn't render an empty page.
+  if (serviceTag.includes('.')) {
+    return { notFound: true };
+  }
+
   const ipRanges = loadServiceTagMap().get(serviceTag) ?? [];
   const cloudsCovered = ALL_CLOUDS.filter((cloud) => ipRanges.some((range) => range.cloud === cloud));
+  const regions = Array.from(new Set(ipRanges.map((range) => range.region).filter(Boolean))).sort();
 
   return {
     props: {
       serviceTag,
-      // Base tags (e.g. "Storage") are unique, content-rich reference pages and are indexed.
-      // Regional variants (e.g. "Storage.WestEurope") are near-duplicates and stay noindexed.
-      isBaseTag: !serviceTag.includes('.'),
       ipRanges,
-      cloudsCovered
+      cloudsCovered,
+      regions
     }
   };
 };

--- a/src/pages/tools/service-tags/[serviceTag].tsx
+++ b/src/pages/tools/service-tags/[serviceTag].tsx
@@ -83,7 +83,9 @@ function loadServiceTagMap(): Map<string, AzureIpAddress[]> {
       for (const prefix of entry.properties.addressPrefixes) {
         const key = `${cloud}|${prefix}`;
         const record: AzureIpAddress = {
-          serviceTagId: base,
+          // Keep the full sub-tag name (e.g. "Storage.WestEurope", "AzureFrontDoor.Backend")
+          // so the table still shows which sub-tag a prefix belongs to after consolidation.
+          serviceTagId: entry.name,
           ipAddressPrefix: prefix,
           region: entry.properties.region || '',
           regionId: entry.properties.regionId || '',
@@ -262,9 +264,11 @@ export const getStaticPaths: GetStaticPaths = async () => {
   try {
     const indexPath = path.join(process.cwd(), 'public', 'data', 'service-tags-index.json');
     const index = JSON.parse(fs.readFileSync(indexPath, 'utf8')) as Array<{ id: string }>;
-    // Only generate base tag pages. Regional variants (IDs with a dot) are consolidated
-    // into their base page and old variant URLs 301-redirect there (see next.config.js).
-    const baseTags = Array.from(new Set(index.map((entry) => entry.id))).filter((id) => !id.includes('.'));
+    // Generate one page per distinct base tag (the part before the first dot). Sub-tags
+    // (regional variants like Storage.WestEurope, or components like AzureFrontDoor.Backend)
+    // are consolidated into their base page and 301-redirect there (see next.config.js).
+    // Using split() also covers families like AzureFrontDoor that have no global entry.
+    const baseTags = Array.from(new Set(index.map((entry) => entry.id.split('.')[0])));
     const paths = baseTags.map((serviceTag) => ({ params: { serviceTag } }));
 
     return {

--- a/src/pages/tools/service-tags/index.tsx
+++ b/src/pages/tools/service-tags/index.tsx
@@ -78,15 +78,33 @@ export default function ServiceTags({ baseServiceTags }: ServiceTagsPageProps) {
     fetchServiceTags();
   }, []);
 
-  // Filter service tags based on search term and cloud filter
-  const filteredServiceTags = useMemo(() => {
+  // Group regional variants (e.g. Storage.WestEurope) into their base tag (Storage).
+  // Variant pages are consolidated into the base page with a region filter, so this
+  // directory lists base tags only and tracks which clouds each one appears in.
+  const baseTags = useMemo(() => {
     if (!data?.serviceTags) return [];
 
-    let filtered = data.serviceTags;
+    const byBase = new Map<string, { id: string; clouds: Set<AzureCloudName> }>();
+    for (const tag of data.serviceTags) {
+      const baseId = tag.id.split('.')[0];
+      let entry = byBase.get(baseId);
+      if (!entry) {
+        entry = { id: baseId, clouds: new Set<AzureCloudName>() };
+        byBase.set(baseId, entry);
+      }
+      entry.clouds.add(tag.cloud);
+    }
+
+    return Array.from(byBase.values()).sort((a, b) => a.id.localeCompare(b.id));
+  }, [data?.serviceTags]);
+
+  // Filter base tags based on search term and cloud filter
+  const filteredServiceTags = useMemo(() => {
+    let filtered = baseTags;
 
     // Apply cloud filter
     if (cloudFilter !== 'all') {
-      filtered = filtered.filter(tag => tag.cloud === cloudFilter);
+      filtered = filtered.filter(tag => tag.clouds.has(cloudFilter));
     }
 
     // Apply search filter
@@ -95,7 +113,7 @@ export default function ServiceTags({ baseServiceTags }: ServiceTagsPageProps) {
     }
 
     return filtered;
-  }, [data?.serviceTags, searchTerm, cloudFilter]);
+  }, [baseTags, searchTerm, cloudFilter]);
 
   // Reset "show all" when filters change
   useEffect(() => {
@@ -262,7 +280,7 @@ export default function ServiceTags({ baseServiceTags }: ServiceTagsPageProps) {
           <div className="space-y-6">
             <div className="text-sm text-slate-600 dark:text-slate-300">
               Showing <span className="font-semibold text-slate-900 dark:text-slate-100">{filteredServiceTags.length}</span> of{' '}
-              <span className="font-semibold text-slate-900 dark:text-slate-100">{data.serviceTags.length}</span> service tags
+              <span className="font-semibold text-slate-900 dark:text-slate-100">{baseTags.length}</span> service tags
               {searchTerm && (
                 <span className="ml-2 rounded-full border border-sky-200 bg-sky-100 px-3 py-1 text-xs font-semibold uppercase text-sky-700 dark:border-sky-800 dark:bg-sky-900/30 dark:text-sky-200">
                   Match: “{searchTerm}”
@@ -275,17 +293,23 @@ export default function ServiceTags({ baseServiceTags }: ServiceTagsPageProps) {
                 <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
                   {visibleServiceTags.map((serviceTag) => (
                     <Link
-                      key={`${serviceTag.id}-${serviceTag.cloud}`}
-                      href={`${getServiceTagPath(serviceTag.id)}?cloud=${encodeURIComponent(serviceTag.cloud)}`}
+                      key={serviceTag.id}
+                      href={getServiceTagPath(serviceTag.id)}
                       className="group rounded-xl bg-white p-4 transition dark:bg-slate-900"
                     >
                       <div className="flex items-center justify-between gap-2">
                         <div className="text-sm font-semibold text-slate-900 transition group-hover:text-sky-700 dark:text-slate-100 dark:group-hover:text-sky-200 truncate">
                           {serviceTag.id}
                         </div>
-                        <span className={`inline-block flex-shrink-0 rounded-md px-2 py-0.5 text-[11px] font-medium ${CLOUD_STYLES[serviceTag.cloud]}`}>
-                          {CLOUD_LABELS[serviceTag.cloud]}
-                        </span>
+                        <div className="flex flex-shrink-0 items-center gap-1">
+                          {([AzureCloudName.AzureCloud, AzureCloudName.AzureChinaCloud, AzureCloudName.AzureUSGovernment] as const)
+                            .filter((cloud) => serviceTag.clouds.has(cloud))
+                            .map((cloud) => (
+                              <span key={cloud} className={`inline-block rounded-md px-2 py-0.5 text-[11px] font-medium ${CLOUD_STYLES[cloud]}`}>
+                                {CLOUD_LABELS[cloud]}
+                              </span>
+                            ))}
+                        </div>
                       </div>
                     </Link>
                   ))}


### PR DESCRIPTION
## What & why

Phase 2 of the SEO rework (Phase 1 = server-rendering base tags, already on `main`).

Previously every regional/sub-tag variant (`Storage.WestEurope`, `AzureFrontDoor.Backend`, …) had its own near-duplicate page: **98 base + 3,479 variant = 3,577 generated pages**. Even with `noindex`, those thin URLs waste Google's crawl budget and drag down the domain's overall quality signal — the "thin programmatic pages" pattern that keeps the site stuck in *Crawled, currently not indexed*.

This consolidates them: **only the base pages are generated (99)**, each absorbing its sub-tag data behind a **region filter**, every old variant URL **301-redirects** to its base page, and the directory grid lists base tags only.

## Key finding: the merge is not lossy

The regional sub-tags are **not** redundant with the global entry. For `Storage` alone, **1,416 prefixes exist only in regional sub-tags** and aren't in the global `Storage` entry. A naive "redirect to the existing base page" would silently drop data the old variant pages (and Bing's index) had.

The base page now merges global + all sub-tag ranges, deduped per `(cloud, prefix)` with the more specific label preferred, so nothing is lost: **Storage shows 2,100 prefixes** (vs 639 global-only) across **90 filterable regions**. Each row keeps its full sub-tag name, so functional sub-tags (e.g. `AzureFrontDoor.Backend` vs `.Frontend`) stay distinguishable.

## Changes

- **`src/lib/serviceTagUrl.ts`** — `getServiceTagPath()` resolves any tag (base or sub-tag) to its base-page URL, repointing every internal link in one place (`Results`, `IpLookupResults`, the directory grid).
- **`src/pages/tools/service-tags/[serviceTag].tsx`** — `getStaticPaths` generates one page per **base family** (99, derived by `split('.')[0]`); `getStaticProps` builds the merged, region-labeled dataset at build time; adds an on-page **Region** filter.
- **`src/pages/tools/service-tags/index.tsx`** — the directory grid groups variants into base tags (one card per base, with cloud badges) instead of listing all 3,745 entries.
- **`next.config.js`** — 301 redirect: any `/tools/service-tags/<tag-with-a-dot>` → its base page.
- **`scripts/generateSitemap.js` + `scripts/generateSiteData.ts`** — base tags derived by `split('.')[0]` so the sitemap (113 URLs) and the static SEO directory stay in sync.

### Edge case handled
`AzureFrontDoor` exists **only** as sub-tags (`.Backend/.Frontend/.FirstParty/.MicrosoftSecurity`) with no global entry. The old "non-dotted IDs" logic skipped it, so its grid card would have 404'd. All base derivations now use `split('.')[0]`, giving **99** base pages.

## Validation

- ✅ Type-check passes; production build succeeds; **99 base pages, 0 variant pages**.
- ✅ Base pages emit `index, follow`; merged data + region filter present in static HTML; AzureFrontDoor page renders with its 4 sub-tags.
- ✅ Redirect tested live against the prod server — all variant forms (no-slash, with-slash, legacy `/service-tags/`) resolve to the base page with **no loops**; base pages and the index are untouched.
- ✅ Directory grid grouping verified to yield 99 cards with no dotted entries.
- ✅ Build time for service-tag pages dropped from **~119s → ~9s**.

## Tradeoff / note

Base pages embed the full merged dataset for client-side filtering. For most tags this is small; a few are heavy uncompressed (AzureCloud 3 MB → ~101 kB gzipped; AzureMonitor 609 kB; DataFactory 216 kB). Still far lighter than the pre–Phase-1 behavior (573 kB cloud fetch on every tag page). A follow-up could cap embedded rows + lazy-load the rest for the handful of large tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)