### PR TITLE
ci: skip Cloudflare preview upload when secrets are unavailable

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -48,8 +48,12 @@ jobs:
         if: github.event_name == 'pull_request'
         run: npx opennextjs-cloudflare build
 
+      # Dependabot and fork PRs run without access to repository secrets, so the
+      # preview upload and its sticky comment cannot work there. Skip them rather
+      # than failing the job — `npm ci` plus the OpenNext build above are the real
+      # signal for those PRs.
       - name: Upload preview version
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && env.CLOUDFLARE_API_TOKEN != ''
         id: preview
         uses: cloudflare/wrangler-action@v3
         with:
@@ -57,8 +61,12 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: versions upload --message "PR #${{ github.event.number }} @ ${{ github.event.pull_request.head.sha }}"
 
+      - name: Note skipped preview upload
+        if: github.event_name == 'pull_request' && env.CLOUDFLARE_API_TOKEN == ''
+        run: echo "::notice::Cloudflare secrets unavailable for this PR, so the preview upload was skipped. The build above still validated the change."
+
       - name: Comment preview URL on PR
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && env.CLOUDFLARE_API_TOKEN != ''
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: cloudflare-preview


### PR DESCRIPTION
## Problem

Every Dependabot PR showed a failing `deploy` check. The failure was environmental, not a real defect:

```
✘ [ERROR] In a non-interactive environment, it's necessary to set a
CLOUDFLARE_API_TOKEN environment variable for wrangler to work.
```

Dependabot (and fork) PRs run without access to repository secrets. `npm ci` and `npx opennextjs-cloudflare build` both **passed**; the job only died at `wrangler versions upload`. The `Comment preview URL on PR` step could not have worked either, since `GITHUB_TOKEN` is read-only on Dependabot PRs regardless of the declared `pull-requests: write` permission.

The net effect was a permanently red check that carried no information, making it impossible to tell a genuinely broken dependency bump from an unavoidable secrets gap.

## Change

Gate the preview upload and its sticky comment on `env.CLOUDFLARE_API_TOKEN != ''`, and emit a `::notice::` when they are skipped so the reason is visible in the run summary.

- PRs **with** secrets: unchanged — preview uploads and the comment posts exactly as before.
- PRs **without** secrets: install + OpenNext build still run and are now the real pass/fail signal.
- Pushes to `main`: untouched, still `npm run deploy`.

Verified the YAML parses and that each step's condition resolves as intended.

https://claude.ai/code/session_01TvnJEucPmRnZSw9e6Yh81r