### PR TITLE
Populate prerendered cache for PR previews

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -58,6 +58,14 @@ jobs:
         if: github.event_name == 'pull_request'
         run: npx opennextjs-cloudflare build
 
+      # `opennextjs-cloudflare deploy` does this for production, but the preview
+      # path calls wrangler directly. Without it the prerendered pages never reach
+      # the assets directory, so every SSG route misses the cache and re-runs
+      # getStaticProps in the worker, which has no filesystem for public/data.
+      - name: Populate prerendered cache into preview assets
+        if: github.event_name == 'pull_request'
+        run: npx opennextjs-cloudflare populateCache local
+
       # Dependabot and fork PRs run without access to repository secrets, so the
       # preview upload and its sticky comment cannot work there. Skip them rather
       # than failing the job — `npm ci` plus the OpenNext build above are the real


### PR DESCRIPTION
PR previews never uploaded the prerendered pages, so every SSG route 500'd or silently rendered empty. Surfaced while testing the VM pricing preview from #219.

## Cause

Production deploys run `npm run deploy` → `opennextjs-cloudflare deploy`, which calls `populateCache` internally before handing off to wrangler. That step copies `.open-next/cache/**` into `.open-next/assets/cdn-cgi/_next_cache/`, where `staticAssetsIncrementalCache` reads it.

The preview path calls `npx opennextjs-cloudflare build` and then `wrangler versions upload` directly, skipping it. The deploy log for #219 shows the result:

```
✨ Read 204 files from the assets directory
```

204 files for 5,428 prerendered pages — none of them present.

## Effect

With no cache entry, the worker falls back to re-running `getStaticProps`, which `open-next.config.ts` explicitly avoids because the worker has no filesystem for the `public/data` reads. Reproduced locally against an unpopulated build:

```
Error: no such file or directory, readAll '/bundle/public/data/vm-pricing/index.json'
  at tc.handleRevalidate
GET /tools/vm-pricing/Standard_B1ls/ 500 Internal Server Error
```

A `wrangler deploy --dry-run` confirms the data genuinely isn't in the worker — one 14.6 MiB `worker.js`, no data files.

This was not new to the VM pricing pages. Service-tag detail pages had the same failure, just silently: `loadServiceTagMap()` wraps each cloud file read in `try {} catch {}`, so the failed read yielded an empty map and a successful-looking page. On the #219 preview, `/tools/service-tags/AppConfiguration/` returned 200 with `x-nextjs-cache: MISS` and:

```
ipRanges: list 0
cloudsCovered: list 0
```

## Verification

After adding the step locally, the assets directory goes from 193 to 5,616 files and the routes serve:

```
/tools/vm-pricing/Standard_B1ls/           200
/tools/vm-pricing/Standard_D2as_v5/        200
/tools/service-tags/AppConfiguration/      200
/tools/vm-pricing/                         200
```

Within Cloudflare's asset limits: 5,616 files against the 20,000 cap, largest single file 5.8 MB against the 25 MiB cap.

The step needs no Cloudflare credentials — for the static-assets cache it is a plain file copy, and the tag cache is skipped — so it is safe on the fork and Dependabot PRs where the upload itself is skipped.

https://claude.ai/code/session_01EahSTi4nwe5BFdeXdWsNdZ
