### PR TITLE
chore(deps): pin uuid to ^11.1.1 via override to clear GHSA-w5hq-g745-h8pq

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12482,12 +12482,16 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
   },
   "overrides": {
     "ip-address": "^10.5.0",
-    "postcss": "^8.5.26"
+    "postcss": "^8.5.26",
+    "uuid": "^11.1.1"
   }
 }


### PR DESCRIPTION
Re-applies the `uuid` override on top of current `main`, so `npm audit` is back to zero after the dependency-PR sweep. Fresh, single-purpose change — nothing else from the old branch is carried over.

## What this fixes

`npm audit` on `main` reports **2 moderate advisories**, both from one chain:

```
exceljs@4.4.0 -> uuid@8.3.2
GHSA-w5hq-g745-h8pq - missing buffer bounds check in uuid v3/v5/v6 when `buf` is supplied
```

## Why it's hygiene, not an incident fix

The advisory is **not reachable** from this codebase. exceljs touches uuid in exactly one place:

```js
// node_modules/exceljs/lib/xlsx/xform/sheet/cf-ext/cf-rule-ext-xform.js
const {v4: uuidv4} = require('uuid');
model.x14Id = `{${uuidv4()}}`.toUpperCase();
```

It calls `v4()` with no arguments, so the vulnerable `buf` path is never entered — and the advisory covers v3/v5/v6, which are not used at all. exceljs itself is only loaded from the browser-side export helpers in `src/lib/exportUtils.ts`, `entraIdExportUtils.ts` and `rbacExportUtils.ts`.

The value is keeping `npm audit` at zero so a genuine advisory doesn't get lost in standing noise.

## Why the major bump is safe here

exceljs destructures `const {v4: uuidv4} = require('uuid')`, and uuid 11 still serves `v4` from its CJS build, so this is API-compatible for the one call site. Verified by exercising the conditional-formatting path that actually calls uuid:

- a `dataBar` rule satisfies `CfRuleExtXform.isExt()`
- `prepare()` emits a valid v4 (`{12C5B19C-4693-4517-BA5D-4072FC1A1FCD}`)
- the uuid-derived `x14Id` lands in `xl/worksheets/sheet1.xml` of the written workbook
- that workbook round-trips back with its values, header styling and CF rules intact

## Changes

Two files, no manifest ranges touched beyond the one override line:

- `package.json` — adds `"uuid": "^11.1.1"` alongside the existing `ip-address` / `postcss` overrides
- `package-lock.json` — `uuid` 8.3.2 → 11.1.1 (the only entry that moves)

The lockfile was regenerated with npm 11 so no unrelated `libc` metadata is stripped from the optional platform packages.

## Verification

| Check | Result |
|---|---|
| `npm audit` | 0 vulnerabilities (was 2 moderate) |
| `npm ls uuid --all` | `exceljs@4.4.0 -> uuid@11.1.1 overridden` |
| `npm ci` | clean |
| `eslint .` | clean |
| `tsc --noEmit` | clean |
| `vitest run` | 152/152 passing |
| `npm run build` | exit 0 |
| exceljs uuid round-trip | x14Id written and reloaded |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XRoPuXpdMNnYi3GN6JZdM

---
_Generated by [Claude Code](https://claude.ai/code/session_014XRoPuXpdMNnYi3GN6JZdM)_